### PR TITLE
Print sizeof for each variable type.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -12,6 +12,11 @@ int main(void)
     /* 64-bit or 32-bit */
     get_bit_num(&bit_num);
     printf("Bit: %d Bit\n", bit_num);
+    /* Sizeof */
+    printf("Sizeof {int, long, long long, void*, size_t, off_t}: "
+        "{%lu, %lu, %lu, %lu, %lu, %lu}\n",
+        sizeof(int), sizeof(long), sizeof(long long),
+        sizeof(void *), sizeof(size_t), sizeof(off_t));
     /* ARCH */
     return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -14,9 +14,10 @@ int main(void)
     printf("Bit: %d Bit\n", bit_num);
     /* Sizeof */
     printf("Sizeof {int, long, long long, void*, size_t, off_t}: "
-        "{%lu, %lu, %lu, %lu, %lu, %lu}\n",
-        sizeof(int), sizeof(long), sizeof(long long),
-        sizeof(void *), sizeof(size_t), sizeof(off_t));
+        "{%u, %u, %u, %u, %u, %u}\n",
+        (unsigned int) sizeof(int), (unsigned int) sizeof(long),
+        (unsigned int) sizeof(long long), (unsigned int) sizeof(void *),
+        (unsigned int) sizeof(size_t), (unsigned int) sizeof(off_t));
     /* ARCH */
     return 0;
 }


### PR DESCRIPTION
Seeing `bowtie2`'s output, printing `sizeof` is useful for each arch.

```
$ bowtie2 --version
/usr/local/bin/../Cellar/bowtie2/2.3.4.1/bin/bowtie2-align-s version 2.3.4.1
64-bit
Built on HighSierra-2.local
Sat Feb  3 15:37:24 GMT 2018
Compiler: InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
Options: -O3 -m64 -msse2 -funroll-loops -g3 -std=c++98 -DPOPCNT_CAPABILITY -DWITH_TBB -DNO_SPINLOCK -DWITH_QUEUELOCK=1
Sizeof {int, long, long long, void*, size_t, off_t}: {4, 8, 8, 8, 8, 8}
```