### PR TITLE
.travis.yml: Use Ubuntu new supported version: xenial.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
+dist: xenial
 language: generic
-dist: trusty
 services: docker
 sudo: false
 os: linux


### PR DESCRIPTION
Ubuntu Xenial 16.04 is available!
https://blog.travis-ci.com/2018-11-08-xenial-release
https://docs.travis-ci.com/user/reference/xenial/

> Docker 18.06
> docker-compose 1.23.1.

`docker-compose` is pre-installed. Nice.
