### PR TITLE
Use build-time args in FROM.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,10 +51,11 @@ install:
   - |
     if [ "${ARCH}" != "" ]; then
       if [ "${BUILD_TYPE}" = "" ]; then
-        sed -i "/^FROM / s/ubuntu/${OS_NAME}/" Dockerfile && \
-        sed -i "/^FROM / s/bionic/${OS_VERSION}/" Dockerfile && \
-        sed -i "/^FROM / s/arm64/${ARCH}/" Dockerfile && \
-          docker build --rm -t sample .
+        docker build --rm -t sample \
+          --build-arg OS_NAME=${OS_NAME} \
+          --build-arg OS_VERSION=${OS_VERSION} \
+          --build-arg ARCH=${ARCH} \
+          .
       fi
     fi
 before_script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
-FROM multiarch/ubuntu-debootstrap:arm64-bionic
+# Docker >= 17.05.0-ce allows using build-time args (ARG) in FROM (#31352).
+# https://github.com/moby/moby/releases/tag/v17.05.0-ce
+ARG OS_NAME=ubuntu
+ARG OS_VERSION=bionic
+ARG ARCH=arm64
+FROM multiarch/${OS_NAME}-debootstrap:${ARCH}-${OS_VERSION}
 
 # Test with non-root user.
 ENV TEST_USER test


### PR DESCRIPTION
Docker >= 17.05.0-ce allows using build-time args (ARG) in FROM

> https://github.com/moby/moby/releases/tag/v17.05.0-ce
> Allow using build-time args (ARG) in FROM