### PR TITLE
Add register image cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,19 @@ os: linux
     script:
       - "echo BASE_IMAGE: ${BASE_IMAGE}"
       - docker run --rm -t "${BASE_IMAGE}" uname -a
+  - &test_in_container_with_register
+    language: bash
+    install:
+      - ls /proc/sys/fs/binfmt_misc/
+      - docker run --rm --privileged multiarch/qemu-user-static:register --reset
+      - ls /proc/sys/fs/binfmt_misc/
+      - |
+        travis_retry docker build --rm -t sample \
+          --build-arg BASE_IMAGE=${BASE_IMAGE} \
+          -f Dockerfile-${OS_NAME} \
+          .
+    script:
+      - docker run --rm -t sample ./sample_test.sh
 
 matrix:
   include:
@@ -50,16 +63,28 @@ matrix:
       env:
         - BASE_IMAGE=i386/ubuntu
       <<: *test_in_container
+    - name: ubuntu-i386-linux-register
+      env:
+        - BASE_IMAGE=multiarch/ubuntu-debootstrap:i386-bionic
+      <<: *test_in_container_with_register
     # ARM, 64-bit, Little-endian
     - name: ubuntu-aarch64-linux
       env:
         - BASE_IMAGE=arm64v8/ubuntu
       <<: *test_in_container
+    - name: ubuntu-aarch64-linux-register
+      env:
+        - BASE_IMAGE=multiarch/ubuntu-debootstrap:arm64-bionic
+      <<: *test_in_container_with_register
     # ARM, 32-bit, Little-endian
     - name: ubuntu-arm32-linux
       env:
         - BASE_IMAGE=arm32v7/ubuntu
       <<: *test_in_container
+    - name: ubuntu-arm32-linux-register
+      env:
+        - BASE_IMAGE=multiarch/ubuntu-debootstrap:armhf-bionic
+      <<: *test_in_container_with_register
     # PowerPC, 64-bit, Little-endian
     - name: ubuntu-ppc64le-linux
       env:
@@ -76,6 +101,11 @@ matrix:
       env:
         - BASE_IMAGE=s390x/ubuntu
       <<: *test_simple_in_container
+    # PowerPC, 64-bit, Big-endian
+    - name: ubuntu-ppc64-linux-register
+      env:
+        - BASE_IMAGE=multiarch/ubuntu-debootstrap:powerpc-xenial
+      <<: *test_in_container_with_register
     # Intel, 32-bit, Little-endian
     - name: debian-i386-linux
       env:


### PR DESCRIPTION
Add deprecated case currently.

But I doubt the deprecated case with register image (`docker run --rm --privileged multiarch/qemu-user-static:register --reset` and the `flags: ` (empty)) has a possibility to be much faster than current recommended case (`docker run --rm --privileged multiarch/qemu-user-static --reset -p yes` and the `flags: F`).

I tried to adapt the recommended way to below `bowtie2` and `nanopolish`. But both are failed with timeout (maximum: 50 minutes) when it worked less than 50 minutes with old way.

https://travis-ci.org/junaruga/bowtie2/builds/582132978
https://travis-ci.org/junaruga/nanopolish/builds/58214a0998

ruby-pg with old way: i386 case: 3 mins 19 secs.
https://travis-ci.org/ged/ruby-pg/builds/574923592

ruby-pg with new recommended way: i386 case: 4 mins 35 secs.
https://travis-ci.org/ged/ruby-pg/builds/582130410
